### PR TITLE
fix: use correct tags for unicode file

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -25,6 +25,10 @@ export function buildOpenApiConfig(version: string, servers: NonNullable<OpenAPI
         name: "Misc",
         description: "Endpoints that don't fit into other categories.",
       },
+      {
+        name: "Files",
+        description: "Endpoints for Unicode Character Database files.",
+      },
     ],
     servers,
   } satisfies OpenAPIObjectConfig;

--- a/src/routes/v1_unicode-files.openapi.ts
+++ b/src/routes/v1_unicode-files.openapi.ts
@@ -5,7 +5,7 @@ import { UnicodeVersionFileSchema } from "./v1_unicode-files.schemas";
 export const GET_UNICODE_FILES_BY_VERSION_ROUTE = createRoute({
   method: "get",
   path: "/{version}",
-  tags: ["Misc"],
+  tags: ["Files"],
   parameters: [
     {
       name: "version",


### PR DESCRIPTION
This PR adds new endpoints to the unicode file route group
