### PR TITLE
feat: support file filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@luxass/unicode-utils": "^0.12.0-beta.5",
     "@scalar/hono-api-reference": "^0.9.1",
     "hono": "^4.7.10",
-    "micromatch": "^4.0.8",
+    "picomatch": "^4.0.2",
     "zod": "^3.25.42"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "@luxass/eslint-config": "^4.18.1",
     "@luxass/spectral-ruleset": "^0.0.5",
     "@stoplight/spectral-cli": "^6.15.0",
-    "@types/micromatch": "^4.0.9",
+    "@types/picomatch": "^4.0.0",
     "eslint": "^9.27.0",
     "eslint-plugin-format": "^1.0.1",
     "nanotar": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@luxass/unicode-utils": "^0.12.0-beta.5",
     "@scalar/hono-api-reference": "^0.9.1",
     "hono": "^4.7.10",
+    "micromatch": "^4.0.8",
     "zod": "^3.25.42"
   },
   "devDependencies": {
@@ -27,6 +28,7 @@
     "@luxass/eslint-config": "^4.18.1",
     "@luxass/spectral-ruleset": "^0.0.5",
     "@stoplight/spectral-cli": "^6.15.0",
+    "@types/micromatch": "^4.0.9",
     "eslint": "^9.27.0",
     "eslint-plugin-format": "^1.0.1",
     "nanotar": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,9 @@ importers:
       hono:
         specifier: ^4.7.10
         version: 4.7.10
-      micromatch:
-        specifier: ^4.0.8
-        version: 4.0.8
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.2
       zod:
         specifier: ^3.25.42
         version: 3.25.42
@@ -39,9 +39,9 @@ importers:
       '@stoplight/spectral-cli':
         specifier: ^6.15.0
         version: 6.15.0
-      '@types/micromatch':
-        specifier: ^4.0.9
-        version: 4.0.9
+      '@types/picomatch':
+        specifier: ^4.0.0
+        version: 4.0.0
       eslint:
         specifier: ^9.27.0
         version: 9.27.0
@@ -1023,9 +1023,6 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
-  '@types/braces@3.0.5':
-    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
-
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1050,9 +1047,6 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
-  '@types/micromatch@4.0.9':
-    resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
-
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1061,6 +1055,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/picomatch@4.0.0':
+    resolution: {integrity: sha512-J1Bng+wlyEERWSgJQU1Pi0HObCLVcr994xT/M+1wcl/yNRTGBupsCxthgkdYG+GCOMaQH7iSVUY3LJVBBqG7MQ==}
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
@@ -4182,8 +4179,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/braces@3.0.5': {}
-
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -4206,10 +4201,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/micromatch@4.0.9':
-    dependencies:
-      '@types/braces': 3.0.5
-
   '@types/ms@2.1.0': {}
 
   '@types/node@22.13.9':
@@ -4217,6 +4208,8 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/picomatch@4.0.0': {}
 
   '@types/sarif@2.1.7': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       hono:
         specifier: ^4.7.10
         version: 4.7.10
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
       zod:
         specifier: ^3.25.42
         version: 3.25.42
@@ -36,6 +39,9 @@ importers:
       '@stoplight/spectral-cli':
         specifier: ^6.15.0
         version: 6.15.0
+      '@types/micromatch':
+        specifier: ^4.0.9
+        version: 4.0.9
       eslint:
         specifier: ^9.27.0
         version: 9.27.0
@@ -1017,6 +1023,9 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1040,6 +1049,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/micromatch@4.0.9':
+    resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4170,6 +4182,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/braces@3.0.5': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -4191,6 +4205,10 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/micromatch@4.0.9':
+    dependencies:
+      '@types/braces': 3.0.5
 
   '@types/ms@2.1.0': {}
 

--- a/src/routes/v1_unicode-files.openapi.ts
+++ b/src/routes/v1_unicode-files.openapi.ts
@@ -16,6 +16,45 @@ export const GET_UNICODE_FILES_BY_VERSION_ROUTE = createRoute({
         type: "string",
       },
     },
+    {
+      name: "exclude",
+      in: "query",
+      required: false,
+      description: "Optional exclude filters to apply to the file list.",
+      schema: {
+        type: "string",
+      },
+    },
+    {
+      name: "includeTests",
+      in: "query",
+      required: false,
+      description: "Whether to include test files in the response.",
+      schema: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    {
+      name: "includeReadmes",
+      in: "query",
+      required: false,
+      description: "Whether to include Readme files in the response.",
+      schema: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    {
+      name: "includeHTMLFiles",
+      in: "query",
+      required: false,
+      description: "Whether to include HTML files in the response.",
+      schema: {
+        type: "boolean",
+        default: false,
+      },
+    },
   ],
   description: "List all UCD files for a specific Unicode version.",
   responses: {

--- a/src/routes/v1_unicode-files.ts
+++ b/src/routes/v1_unicode-files.ts
@@ -26,6 +26,21 @@ V1_UNICODE_FILES_ROUTER.get("*", cache({
 
 V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) => {
   const version = c.req.param("version");
+  const {
+    exclude,
+    includeTests = false,
+    includeReadmes = false,
+    includeHTMLFiles = false,
+  } = c.req.query();
+
+  // eslint-disable-next-line no-console
+  console.info({
+    exclude,
+    includeTests,
+    includeReadmes,
+    includeHTMLFiles,
+    version,
+  });
 
   if (!UNICODE_VERSION_METADATA.map((v) => v.version)
     .includes(version as typeof UNICODE_VERSION_METADATA[number]["version"])) {
@@ -66,11 +81,7 @@ V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) =>
     // process all files
     const fileEntries = entries
       .filter((entry) => {
-        return entry.type === "file"
-          && entry.name.endsWith(".txt")
-          && (entry.name !== "ReadMe.txt.txt"
-            || !entry.path.includes("draft")
-            || !entry.path.includes("latest"));
+        return entry.type === "file";
       })
       .map((file) => ({
         name: file.name,

--- a/src/routes/v1_unicode-files.ts
+++ b/src/routes/v1_unicode-files.ts
@@ -34,15 +34,6 @@ V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) =>
     includeHTMLFiles = false,
   } = c.req.query();
 
-  // eslint-disable-next-line no-console
-  console.info({
-    exclude,
-    includeTests,
-    includeReadmes,
-    includeHTMLFiles,
-    version,
-  });
-
   if (!UNICODE_VERSION_METADATA.map((v) => v.version)
     .includes(version as typeof UNICODE_VERSION_METADATA[number]["version"])) {
     return createError(c, 400, "Unicode version does not have UCD");
@@ -59,6 +50,10 @@ V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) =>
     version,
     mappedVersion,
     extraPath,
+    exclude,
+    includeTests,
+    includeReadmes,
+    includeHTMLFiles,
   });
 
   const excludePatterns = exclude?.split(",").map((p) => p.trim()).filter(Boolean) || [];
@@ -124,6 +119,8 @@ V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) =>
         const fullPath = prefix ? `${prefix}/${entry.path}` : entry.path;
 
         if (!entry.children) {
+          // eslint-disable-next-line no-console
+          console.info(`Checking file: ${fullPath}`, isMatch(fullPath));
           if (isMatch(fullPath)) {
             result.push(entry);
           }

--- a/src/routes/v1_unicode-files.ts
+++ b/src/routes/v1_unicode-files.ts
@@ -117,8 +117,6 @@ V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) =>
         const fullPath = prefix ? `${prefix}/${entry.path}` : entry.path;
 
         if (!entry.children) {
-          // eslint-disable-next-line no-console
-          console.info(`Checking file: ${fullPath}`, isMatch(fullPath));
           if (!isMatch(fullPath)) {
             result.push(entry);
           }

--- a/src/routes/v1_unicode-files.ts
+++ b/src/routes/v1_unicode-files.ts
@@ -106,9 +106,7 @@ V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) =>
   function filterEntriesRecursive(entries: Entry[]) {
     if (excludePatterns.length === 0) return entries;
 
-    const patterns = ["**", ...excludePatterns.map((pattern) => `!${pattern}`)];
-    console.error("PATTERNS", patterns);
-    const isMatch = picomatch(patterns, {
+    const isMatch = picomatch(excludePatterns, {
       dot: true,
       nocase: true,
     });
@@ -121,7 +119,7 @@ V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) =>
         if (!entry.children) {
           // eslint-disable-next-line no-console
           console.info(`Checking file: ${fullPath}`, isMatch(fullPath));
-          if (isMatch(fullPath)) {
+          if (!isMatch(fullPath)) {
             result.push(entry);
           }
         } else {

--- a/src/routes/v1_unicode-files.ts
+++ b/src/routes/v1_unicode-files.ts
@@ -107,7 +107,7 @@ V1_UNICODE_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) =>
     if (excludePatterns.length === 0) return entries;
 
     const patterns = ["**", ...excludePatterns.map((pattern) => `!${pattern}`)];
-
+    console.error("PATTERNS", patterns);
     const isMatch = picomatch(patterns, {
       dot: true,
       nocase: true,


### PR DESCRIPTION
This PR resolves #2 by removing the default applied filters, and instead allows users to configure the filtering.

This means that there is now 4 new query params:
- `exclude`: Provide Exclude Patterns for excluding files matching the pattern
- `includeTests`: (default: false) Include Test Files
- `includeReadmes`: (default: false) Include Readme.txt files
- `includeHTMLFiles`: (default: false) Include HTML Files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new query parameters to the Unicode files API endpoint, allowing users to exclude files by pattern and to include or exclude test files, Readme files, and HTML files in the results.

- **Chores**
  - Updated dependencies to include support for advanced file pattern matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->